### PR TITLE
refactor: remove useGetRoomId hook

### DIFF
--- a/project-4/common/types/index.ts
+++ b/project-4/common/types/index.ts
@@ -23,7 +23,7 @@ export type Nullable<T> = T | null;
 
 export type QoraContextType = {
   socket: TSocket;
-  roomId: string;
+  roomId: RoomId;
   peer: Peer;
   user: Pick<UserContext, 'user'>;
   isHost: boolean;

--- a/project-4/hooks/index.ts
+++ b/project-4/hooks/index.ts
@@ -1,6 +1,5 @@
 import usePeer from './use-peer';
 import useStream from './use-stream';
-import useGetRoomId from './use-get-room-id';
 import usePeerOnJoinRoom from './use-peer-on-join-room';
 import usePeerOnAnswer from './use-peer-on-answer';
 import useScreenShare from './use-screen-share';
@@ -9,7 +8,6 @@ import useIsAudioActive from './use-is-audio-active';
 export {
   usePeer,
   useStream,
-  useGetRoomId,
   usePeerOnJoinRoom,
   usePeerOnAnswer,
   useScreenShare,

--- a/project-4/hooks/use-get-room-id.ts
+++ b/project-4/hooks/use-get-room-id.ts
@@ -1,9 +1,0 @@
-import { useRouter } from 'next/router';
-
-const useGetRoomId = () => {
-  const router = useRouter();
-  const { qoraId: roomId } = router.query as { qoraId: string };
-  return roomId;
-};
-
-export default useGetRoomId;

--- a/project-4/pages/api/auth/[...auth0].ts
+++ b/project-4/pages/api/auth/[...auth0].ts
@@ -1,8 +1,3 @@
 import { handleAuth, handleLogin } from '@auth0/nextjs-auth0';
+export default handleAuth();
 
-export default handleAuth({
-  async login(req, res) {
-    // const roomId = req.headers.referer?.split('/').at(-1)
-    await handleLogin(req, res, { returnTo: '/' });
-  },
-});


### PR DESCRIPTION
What does the PR do:
- removes `useGetRoomId` absctraction
- removes `roomId` from `Qora Context` value
- adds bit more descriptive `tsdoc` to `usePeer`
- removes `if` check  for `user`, due to it is guaranteed that at that point of app there is an `user`