### PR TITLE
[refactor | project-4]: loader-error-msg component, separate socket from context

### DIFF
--- a/project-4/app/index.tsx
+++ b/project-4/app/index.tsx
@@ -6,7 +6,12 @@ import { ToastContainer } from 'react-toastify';
 
 import { MediaSetup, KeyValue, Nullable, RoomId } from '@common/types';
 import { append, isHost } from '@common/utils';
-import { MYSELF, TOAST_PROPS } from '@common/constants';
+import {
+  FAILURE_MSG,
+  LOADER_PEER_MSG,
+  MYSELF,
+  TOAST_PROPS,
+} from '@common/constants';
 
 import { usePeer } from '@hooks/index';
 import { SocketContext } from '@pages/_app';
@@ -16,6 +21,7 @@ import Botqa from '@components/botqa';
 import Chat from '@components/chat';
 import ControlPanel from '@components/control-panel';
 import { PeerVideo, VideoContainer } from '@components/index';
+import LoaderError from '@common/components/loader-error';
 
 const Room = ({
   stream,
@@ -56,24 +62,12 @@ const Room = ({
     };
   }, []);
 
-  if (!isPeerReady)
-    return (
-      <div className="grid place-items-center h-screen text-white">
-        Setting you up... 🎮
-      </div>
-    );
-
-  if (!peer)
-    return (
-      <div className="grid place-items-center h-screen text-white">
-        Oooops!!! Couldn't create connection. Try again later 🫠
-      </div>
-    );
+  if (!isPeerReady) return <LoaderError msg={LOADER_PEER_MSG} />;
+  if (!peer) return <LoaderError msg={FAILURE_MSG} />;
 
   return (
     <QoraContext.Provider
       value={{
-        socket,
         peer,
         myId,
         isHost: isHost(room),

--- a/project-4/app/index.tsx
+++ b/project-4/app/index.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useState } from 'react';
-import { useRouter } from 'next/router';
+import { Router, useRouter } from 'next/router';
 import { useUser } from '@auth0/nextjs-auth0';
 import { MediaConnection } from 'peerjs';
 import { ToastContainer } from 'react-toastify';
@@ -30,7 +30,7 @@ const Room = ({
   stream: MediaStream;
   initMediaSetup: MediaSetup;
 }) => {
-  const room = useRouter().query.qoraId as RoomId;
+  const router = useRouter();
   const userPicture = useUser().user!.picture;
   const socket = useContext(SocketContext);
   const { peer, myId, isPeerReady } = usePeer(initMediaSetup);
@@ -70,7 +70,7 @@ const Room = ({
       value={{
         peer,
         myId,
-        isHost: isHost(room),
+        isHost: isHost(router.query.qoraId as RoomId),
         mediaSetup,
         stream,
         peers,
@@ -104,6 +104,7 @@ const Room = ({
 
           <div className="flex w-full items-center">
             <ControlPanel
+              onLeave={() => router.push('/')}
               isChatOpen={isChatOpen}
               usersCount={count + Number(Boolean(myId))}
               onFullscreen={() => setFullscreen(!fullscreen)}

--- a/project-4/common/components/loader-error.tsx
+++ b/project-4/common/components/loader-error.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function LoaderError({ msg }: { msg: string }) {
+  return (
+    <div className="grid place-items-center h-screen text-white">{msg}</div>
+  );
+}

--- a/project-4/common/constants/index.ts
+++ b/project-4/common/constants/index.ts
@@ -9,3 +9,8 @@ export const TOAST_PROPS: ToastContainerProps = {
   theme: 'dark',
   autoClose: 3000,
 };
+export const FAILURE_MSG =
+  "Ooops!!! Couldn't create stream for you. Try again later 🫠";
+export const LOADER_STREAM_MSG =
+  'Hold on. Getting your video stream ready... 🚀';
+export const LOADER_PEER_MSG = 'Setting you up... 🎮';

--- a/project-4/components/botqa/index.tsx
+++ b/project-4/components/botqa/index.tsx
@@ -6,15 +6,16 @@ import { PeerVideo, SharedScreen, VideoContainer } from '@components/index';
 import { usePeerOnJoinRoom, usePeerOnAnswer } from '@hooks/index';
 import { append, toggleAudio } from 'common/utils';
 import { KeyValue, PeerId } from 'common/types';
+import { SocketContext } from '@pages/_app';
 
 const Room = ({ fullscreen, onMuteUser, children }: RoomProps) => {
   console.log('render app');
+  const socket = useContext(SocketContext);
 
   const {
     myId,
     peers,
     stream,
-    socket,
     setCount,
     sharedScreenTrack,
     setSharedScreenTrack,

--- a/project-4/components/chat/index.tsx
+++ b/project-4/components/chat/index.tsx
@@ -6,10 +6,11 @@ import { MYSELF } from '@common/constants';
 import { append, formatTimeHHMM } from '@common/utils';
 import { Message } from '..';
 import { useUser } from '@auth0/nextjs-auth0';
+import { SocketContext } from '@pages/_app';
 
 const Chat = ({ title, onClose }: { title: string; onClose: () => void }) => {
   const username = useUser().user!.name;
-  const socket = useContext(QoraContext).socket;
+  const socket = useContext(SocketContext);
 
   const [text, setText] = useState('');
   const [messages, setMessages] = useState<UserMessage[]>([]);

--- a/project-4/components/control-panel/index.tsx
+++ b/project-4/components/control-panel/index.tsx
@@ -25,6 +25,7 @@ const ControlPanel = ({
   setMediaSetup,
   toggleChat,
   isChatOpen,
+  onLeave,
 }: ControlPanelProps) => {
   const router = useRouter();
   const socket = useContext(SocketContext);
@@ -85,7 +86,7 @@ const ControlPanel = ({
         <Tooltip id="audio" effect="solid" />
 
         <button
-          onClick={() => router.push('/')}
+          onClick={onLeave}
           data-for="hangUp"
           data-tip="hang up"
           className={`${common} bg-red-600 hover:bg-red-500`}
@@ -141,6 +142,7 @@ type ControlPanelProps = {
   setMediaSetup: (key: keyof MediaSetup) => void;
   toggleChat: (arg: boolean) => void;
   onFullscreen: () => void;
+  onLeave: () => void;
 };
 
 const common = 'p-3 rounded-xl text-white';

--- a/project-4/components/control-panel/index.tsx
+++ b/project-4/components/control-panel/index.tsx
@@ -17,6 +17,7 @@ import { useScreenShare } from '@hooks/index';
 import CrossLineDiv from '@common/components/cross-line-div';
 import { toggleAudio, toggleVideo } from '@common/utils';
 import { MediaSetup } from '@common/types';
+import { SocketContext } from '@pages/_app';
 
 const ControlPanel = ({
   usersCount,
@@ -26,6 +27,7 @@ const ControlPanel = ({
   isChatOpen,
 }: ControlPanelProps) => {
   const router = useRouter();
+  const socket = useContext(SocketContext);
 
   const {
     myId,
@@ -33,7 +35,6 @@ const ControlPanel = ({
     mediaSetup,
     stream,
     sharedScreenTrack: shared,
-    socket,
   } = useContext(QoraContext);
   const { isMyScreenSharing, toggleScreenShare } = useScreenShare();
 

--- a/project-4/hooks/use-peer-on-join-room.ts
+++ b/project-4/hooks/use-peer-on-join-room.ts
@@ -5,6 +5,7 @@ import { QoraContext } from '@pages/qora/[qoraId]';
 import { AppendVideoStream, KeyValue, MediaSetup } from '@common/types';
 import { append } from '@common/utils';
 import { useUser } from '@auth0/nextjs-auth0';
+import { SocketContext } from '@pages/_app';
 
 /**
  * Actor - user that is in the room already.
@@ -29,8 +30,9 @@ const usePeerOnJoinRoom = (
   setUserPictures: Dispatch<SetStateAction<KeyValue<string>>>
 ) => {
   const user = useUser().user!;
-  const { mediaSetup, socket, peer, setPeers, stream } =
-    useContext(QoraContext);
+  const socket = useContext(SocketContext);
+
+  const { mediaSetup, peer, setPeers, stream } = useContext(QoraContext);
 
   useEffect(() => {
     if (!peer) return;

--- a/project-4/hooks/use-screen-share.ts
+++ b/project-4/hooks/use-screen-share.ts
@@ -3,11 +3,13 @@ import { toast } from 'react-toastify';
 import { QoraContext } from '@pages/qora/[qoraId]';
 import { error } from '@common/utils';
 import { useUser } from '@auth0/nextjs-auth0';
+import { SocketContext } from '@pages/_app';
 
 const useScreenShare = () => {
-  const username = useUser().user!.name
+  const username = useUser().user!.name;
+  const socket = useContext(SocketContext);
+
   const {
-    socket,
     peer,
     stream,
     sharedScreenTrack: sharedTrack,

--- a/project-4/pages/qora/[qoraId].tsx
+++ b/project-4/pages/qora/[qoraId].tsx
@@ -7,6 +7,8 @@ import { Lobby } from '@components/index';
 import { useStream } from '@hooks/index';
 import { append } from '@common/utils';
 import { MediaSetup } from '@common/types';
+import LoaderError from '@common/components/loader-error';
+import { FAILURE_MSG, LOADER_STREAM_MSG } from '@common/constants';
 
 export const QoraContext = createContext<any>({});
 
@@ -19,20 +21,9 @@ const Qora: NextPage = () => {
   });
   const { stream, isLoading } = useStream({ video: true, audio: true });
 
-  if (isLoading)
-    return (
-      <div className="grid place-items-center h-screen text-white">
-        Hold on. Getting your video stream ready... 🚀
-      </div>
-    );
-
-  if (!stream)
-    return (
-      <div className="grid place-items-center h-screen text-white">
-        Ooops!!! Couldn't create stream for you. Try again later 🫠
-      </div>
-    );
-
+  if (isLoading) return <LoaderError msg={LOADER_STREAM_MSG} />;
+  if (!stream) return <LoaderError msg={FAILURE_MSG} />;
+  
   return isLobby ? (
     <Lobby
       stream={stream}


### PR DESCRIPTION
What does the PR do:
- removes `socket` from `QoraContext`
- imports `socket` from `SocketContext` where it is needed
- creates `LoaderError` component to display loading or error state messages
- brings `router.push` inside `ControlPanel` to outside for easier control