### PR TITLE
[project-4 | refactor]: use-media-stream hook enhanced

### DIFF
--- a/project-4/app/index.tsx
+++ b/project-4/app/index.tsx
@@ -22,22 +22,24 @@ import Chat from '@components/chat';
 import ControlPanel from '@components/control-panel';
 import { PeerVideo, VideoContainer } from '@components/index';
 import LoaderError from '@common/components/loader-error';
+import useMediaStream from '@hooks/use-media-stream';
 
-const Room = ({
-  stream,
-  initMediaSetup,
-}: {
-  stream: MediaStream;
-  initMediaSetup: MediaSetup;
-}) => {
+const Room = ({ stream }: { stream: MediaStream }) => {
   const router = useRouter();
   const userPicture = useUser().user!.picture;
   const socket = useContext(SocketContext);
-  const { peer, myId, isPeerReady } = usePeer(initMediaSetup);
+  const { muted, visible } = useMediaStream(stream);
+  const { peer, myId, isPeerReady } = usePeer({
+    isHidden: !visible,
+    isMuted: muted,
+  });
 
   const [peers, setPeers] = useState<KeyValue<MediaConnection>>({});
 
-  const [mediaSetup, setMediaSetup] = useState(initMediaSetup);
+  const [mediaSetup, setMediaSetup] = useState({
+    isHidden: !visible,
+    isMuted: muted,
+  });
   const [sharedScreenTrack, setSharedScreenTrack] =
     useState<Nullable<MediaStreamTrack>>(null);
 

--- a/project-4/common/types/index.ts
+++ b/project-4/common/types/index.ts
@@ -62,3 +62,6 @@ export type MediaSetup = {
   isMuted: boolean;
   isHidden: boolean;
 };
+
+export type Status = 'loading' | 'idle' | 'rejected' | 'success';
+

--- a/project-4/components/lobby/index.tsx
+++ b/project-4/components/lobby/index.tsx
@@ -8,31 +8,24 @@ import CrossLineDiv from '@common/components/cross-line-div';
 import { MediaSetup } from '@common/types';
 
 import { PeerVideo, VideoContainer } from '..';
+import useMediaStream from '@hooks/use-media-stream';
 
 const Lobby = ({
   stream,
-  initMediaSetup,
-  setup,
-  redirectToRoom,
-}: LobbyProps) => {
+  onJoinRoom,
+}: {
+  stream: MediaStream;
+  onJoinRoom: () => void;
+}) => {
   const user = useUser().user;
-
-  function setVisibility() {
-    setup('isHidden');
-    toggleVideo(stream);
-  }
-
-  function setMuted() {
-    setup('isMuted');
-    toggleAudio(stream);
-  }
+  const { muted, visible, toggle } = useMediaStream(stream);
 
   return (
     <div className="h-screen w-auto grid grid-cols-2 gap-4 place-content-center place-items-center">
       <div className="flex flex-col gap-2">
         <VideoContainer
           id="me"
-          mediaSetup={initMediaSetup}
+          mediaSetup={{ isHidden: !visible, isMuted: muted }}
           stream={stream}
           userPicture={user?.picture || ''}
         >
@@ -41,31 +34,31 @@ const Lobby = ({
 
         <div className="flex justify-end gap-2">
           <button
-            onClick={setVisibility}
+            onClick={() => toggle('video')(stream)}
             data-for="visibility"
-            data-tip={`${initMediaSetup.isHidden ? 'switch on' : 'switch off'}`}
+            data-tip={`${!visible ? 'switch on' : 'switch off'}`}
             className="p-3 rounded-xl text-white bg-slate-800 hover:bg-indigo-700 relative"
           >
             <VideoCameraIcon className="h-6 w-6" />
-            {initMediaSetup.isHidden && <CrossLineDiv />}
+            {!visible && <CrossLineDiv />}
           </button>
           <Tooltip id="visibility" effect="solid" />
 
           <button
-            onClick={setMuted}
+            onClick={() => toggle('audio')(stream)}
             data-for="audio"
-            data-tip={`${initMediaSetup.isMuted ? 'unmute' : 'mute'}`}
+            data-tip={`${muted ? 'unmute' : 'mute'}`}
             className="p-3 rounded-xl text-white bg-slate-800 hover:bg-indigo-700 relative"
           >
             <MicrophoneIcon className="h-6 w-6" />
-            {initMediaSetup.isMuted && <CrossLineDiv />}
+            {muted && <CrossLineDiv />}
           </button>
           <Tooltip id="audio" effect="solid" />
         </div>
       </div>
 
       <button
-        onClick={redirectToRoom}
+        onClick={onJoinRoom}
         type="button"
         className="p-2 text-sm font-medium rounded-md text-emerald-800 bg-emerald-300 hover:bg-indigo-200"
       >
@@ -76,10 +69,3 @@ const Lobby = ({
 };
 
 export default Lobby;
-
-type LobbyProps = {
-  stream: MediaStream;
-  initMediaSetup: MediaSetup;
-  setup: (key: keyof MediaSetup) => void;
-  redirectToRoom: () => void;
-};

--- a/project-4/pages/qora/[qoraId].tsx
+++ b/project-4/pages/qora/[qoraId].tsx
@@ -9,33 +9,21 @@ import { append } from '@common/utils';
 import { MediaSetup } from '@common/types';
 import LoaderError from '@common/components/loader-error';
 import { FAILURE_MSG, LOADER_STREAM_MSG } from '@common/constants';
+import useMediaStream from '@hooks/use-media-stream';
 
 export const QoraContext = createContext<any>({});
 
 const Qora: NextPage = () => {
   const [isLobby, setIsLobby] = useState(true);
-
-  const [initMediaSetup, setInitMediaSetup] = useState<MediaSetup>({
-    isMuted: false,
-    isHidden: false,
-  });
-  const { stream, isLoading } = useStream({ video: true, audio: true });
+  const { stream, isLoading } = useMediaStream();
 
   if (isLoading) return <LoaderError msg={LOADER_STREAM_MSG} />;
   if (!stream) return <LoaderError msg={FAILURE_MSG} />;
-  
-  return isLobby ? (
-    <Lobby
-      stream={stream}
-      initMediaSetup={initMediaSetup}
-      redirectToRoom={() => setIsLobby(false)}
-      setup={(key: keyof MediaSetup) =>
-        setInitMediaSetup(append({ [key]: !initMediaSetup[key] }))
-      }
-    />
-  ) : (
-    <Room stream={stream} initMediaSetup={initMediaSetup} />
-  );
+
+  if (isLobby)
+    return <Lobby stream={stream} onJoinRoom={() => setIsLobby(false)} />;
+
+  return <Room stream={stream} />;
 };
 
 export default Qora;


### PR DESCRIPTION
This PR:
- creates `use-media-stream` hook to handle stream
- replaces `mediaSetup` object to use `muted` , `visible` states