### PR TITLE
expand a bit withPageAuthRequired

### DIFF
--- a/project-4/pages/qora/[qoraId].tsx
+++ b/project-4/pages/qora/[qoraId].tsx
@@ -2,15 +2,12 @@ import { NextPage } from 'next';
 import { createContext, useState } from 'react';
 import { withPageAuthRequired } from '@auth0/nextjs-auth0';
 
-// import Room from '@app/index';
-import Room from '../../app/app';
 import { Lobby } from '@components/index';
-import { useStream } from '@hooks/index';
-import { append } from '@common/utils';
-import { MediaSetup } from '@common/types';
 import LoaderError from '@common/components/loader-error';
 import { FAILURE_MSG, LOADER_STREAM_MSG } from '@common/constants';
 import useMediaStream from '@hooks/use-media-stream';
+
+import Room from '../../app/app';
 
 export const QoraContext = createContext<any>({});
 
@@ -29,4 +26,8 @@ const Qora: NextPage = () => {
 
 export default Qora;
 
-export const getServerSideProps = withPageAuthRequired();
+export const getServerSideProps = async (ctx: any) =>
+  await withPageAuthRequired({
+    returnTo: '/qora/' + ctx.query.qoraId,
+  })(ctx);
+


### PR DESCRIPTION
### What was the bug:

When `user` isn't logged in and clicks `Jana Qora` and get's redirect to `login` page, and once user logged in and redirect back to where they left off, `url` had queryParam as `qora/${qoraId}?qoraId=${qoraId}`.

The url has to be `qora/${qoraId}`

This PR:
- fixes the issue mentioned above
- removes some unused imports

Where the solution came from: [here](https://auth0.github.io/nextjs-auth0/modules/helpers_with_page_auth_required.html)

What other references were red:
- [source code of next/auth0-sdk](https://github.com/auth0/nextjs-auth0/blob/cc75175/src/frontend/with-page-auth-required.tsx#L75)
- [stackoverflow](https://stackoverflow.com/questions/68201349/next-js-withpageauthrequired-with-getstaticprops)
