### PR TITLE
[project-5] ➡️ Theme, Lang Toggler,  Time to right of the page

### DIFF
--- a/project-5/components/lang-toggler/index.tsx
+++ b/project-5/components/lang-toggler/index.tsx
@@ -8,7 +8,7 @@ export default function LangToggler({ lang }: { lang: Lang }) {
   const setLang = useContext(LangContext);
 
   return (
-    <>
+    <div>
       {/* english */}
       <input
         className={`hidden peer/en ${lang == LANG.EN ? "checked" : ""}`}
@@ -70,6 +70,6 @@ export default function LangToggler({ lang }: { lang: Lang }) {
         {" "}
         ru
       </label>
-    </>
+    </div>
   );
 }

--- a/project-5/components/theme-toggler/index.tsx
+++ b/project-5/components/theme-toggler/index.tsx
@@ -32,7 +32,7 @@ export default function ThemeToggler() {
   }
 
   return (
-    <div className="relative">
+    <div className="relative mt-0.5">
       <motion.button
         animate={theme === "light" ? "hidden" : "show"}
         variants={variants}

--- a/project-5/package.json
+++ b/project-5/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.0.13",
+    "@next/font": "^13.0.5",
     "@types/node": "18.11.9",
     "@types/react": "18.0.25",
     "@types/react-dom": "18.0.9",

--- a/project-5/pages/_app.tsx
+++ b/project-5/pages/_app.tsx
@@ -1,16 +1,26 @@
 import type { AppProps } from 'next/app'
+import { Rubik } from "@next/font/google";
 
-import ThemeProvider from '~contexts/theme-provider'
-import LangProvider from '~contexts/lang-provider'
+import ThemeProvider from "~contexts/theme-provider";
+import LangProvider from "~contexts/lang-provider";
 
-import '../styles/globals.css'
+import "../styles/globals.css";
+
+const font = Rubik();
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <LangProvider>
-      <ThemeProvider>
-        <Component {...pageProps} />
-      </ThemeProvider>
-    </LangProvider>
-  )
+    <>
+      <style jsx global>{`
+        html {
+          font-family: ${font.style.fontFamily};
+        }
+      `}</style>
+      <LangProvider>
+        <ThemeProvider>
+          <Component {...pageProps} />
+        </ThemeProvider>
+      </LangProvider>
+    </>
+  );
 }

--- a/project-5/pages/index.tsx
+++ b/project-5/pages/index.tsx
@@ -25,13 +25,13 @@ const Home: NextPage = () => {
         <meta name="description" content="NR" />
       </Head>
       <RoundedCorner>
-        <div className="flex gap-x-5">
+        <div className="flex gap-x-5 justify-end px-6">
           <CurrentTime />
-          <div>
-            <LangToggler lang={locale as Lang} />
-            <span className="place-content-center">{t.welcome}</span>
-          </div>
+          <LangToggler lang={locale as Lang} />
           <ThemeToggler />
+        </div>
+        <div className="grid h-full place-content-center text-5xl dark:text-white">
+          {t.welcome}
         </div>
       </RoundedCorner>
     </div>

--- a/project-5/yarn.lock
+++ b/project-5/yarn.lock
@@ -681,6 +681,11 @@
   dependencies:
     glob "7.1.7"
 
+"@next/font@^13.0.5":
+  version "13.0.5"
+  resolved "https://registry.yarnpkg.com/@next/font/-/font-13.0.5.tgz#db0ef389d926d3a8b649db8aa76e67f9502a478f"
+  integrity sha512-NrP4B8pxwerrkkuG/m7MQv0ks89Kk4Lc0kzbiRaYX+Xb0coDaw+I9T+g42aOHf8j8ta1vtKqb5XE1+troZ4CoQ==
+
 "@next/swc-android-arm-eabi@13.0.4":
   version "13.0.4"
   resolved "https://registry.yarnpkg.com/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.0.4.tgz#684fe26ff2a05b9dd8c4fb84bc87ba807e3bddc0"


### PR DESCRIPTION
This PR:
- moves `ThemeToggler`, `LangToggler` and `Time` components to the right
- installs `next/fonts` lib
- applies `Rubik` google font
- centers `Hi there` text 

Screen
<img width="1800" alt="Screenshot 2022-11-27 at 20 14 23" src="https://user-images.githubusercontent.com/27337196/204155215-768f7b07-85c6-4cd7-bf37-b22dee1b66d1.png">
