### PR TITLE
[project-5] 🌍🚏 global next/router mock

### DIFF
--- a/project-5/common/components/header/index.test.tsx
+++ b/project-5/common/components/header/index.test.tsx
@@ -1,15 +1,7 @@
+import { render, screen, within } from 'common/utils/test-utils'
 import { useRouter as mockedUseRouter } from 'next/router'
 
-import { render, screen, within } from 'common/utils/test-utils'
-
 import Header from '.'
-
-jest.mock('next/router', () => ({
-  useRouter: jest.fn(() => ({
-    route: '/',
-    locale: 'en',
-  })),
-}))
 
 describe('Navigation Menu', () => {
   it('"Home" item should be active by default', () => {
@@ -25,7 +17,10 @@ describe('Navigation Menu', () => {
   })
 
   it('should switch active menu item', () => {
-    ;(mockedUseRouter as any).mockImplementation(() => ({ route: '/projects', locale: 'en' }))
+    ;(mockedUseRouter as any).mockImplementation(() => ({
+      route: '/projects',
+      locale: 'en',
+    }))
 
     render(<Header>yo</Header>)
     const projectsItem = screen.getByText(/projects/i).parentElement

--- a/project-5/components/lang-toggler/index.test.tsx
+++ b/project-5/components/lang-toggler/index.test.tsx
@@ -1,12 +1,7 @@
+import { render, screen, fireEvent } from 'common/utils/test-utils'
 import { useRouter as mockedUseRouter } from 'next/router'
 
-import { render, screen, fireEvent } from 'common/utils/test-utils'
-
 import LangToggler from '.'
-
-jest.mock('next/router', () => ({
-  useRouter: jest.fn(),
-}))
 
 describe('Language Toggler Component', () => {
   it('"english" language should be checked by default', () => {
@@ -18,7 +13,10 @@ describe('Language Toggler Component', () => {
 
   it('"german" should be checked once selected', async () => {
     const push = jest.fn()
-    ;(mockedUseRouter as jest.Mock).mockImplementation(() => ({ push, route: '/de' }))
+    ;(mockedUseRouter as jest.Mock).mockImplementation(() => ({
+      push,
+      route: '/de',
+    }))
     const { rerender } = render(<LangToggler lang="en" />)
 
     screen.getByRole('radio-de')

--- a/project-5/components/theme-toggler/index.test.tsx
+++ b/project-5/components/theme-toggler/index.test.tsx
@@ -8,10 +8,6 @@ global.Audio = jest.fn().mockImplementation(() => ({
   play: audioPlay,
 }))
 
-jest.mock('next/router', () => ({
-  useRouter: jest.fn(),
-}))
-
 describe('Theme Toggler Component', () => {
   it('should not contain the "dark" class initially attached to the html', () => {
     const isDark = document.documentElement.classList.contains('dark')

--- a/project-5/contexts/cursor-provider.test.tsx
+++ b/project-5/contexts/cursor-provider.test.tsx
@@ -2,13 +2,6 @@ import userEvent from '@testing-library/user-event'
 import Header from 'common/components/header'
 import { render, screen, waitFor } from 'common/utils/test-utils'
 
-jest.mock('next/router', () => ({
-  useRouter: jest.fn(() => ({
-    route: '/',
-    locale: 'en',
-  })),
-}))
-
 describe('Custom Cursor', () => {
   function setup() {
     return render(

--- a/project-5/jest.setup.js
+++ b/project-5/jest.setup.js
@@ -1,2 +1,9 @@
 /** @type {import('next').NextConfig} */
 import '@testing-library/jest-dom/extend-expect';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(() => ({
+    route: '/',
+    locale: 'en',
+  })),
+}))


### PR DESCRIPTION
This PR:
- unifies `next/router` mock inside `jest.setup.js` file
- removes `next/router` mock from `*.test.ts|tsx` files